### PR TITLE
add property to disable nats

### DIFF
--- a/nats/src/main/java/io/micronaut/nats/package-info.java
+++ b/nats/src/main/java/io/micronaut/nats/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Configuration for Nats.
+ */
+@Configuration
+@Requires(classes = {Connection.class})
+@Requires(property = "nats.enabled", notEquals = StringUtils.FALSE)
+package io.micronaut.nats;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.nats.client.Connection;


### PR DESCRIPTION
Add a package-info to disable all nats beans. Also add requirement to make sure nats client Connection class is present in the classloader.