### PR TITLE
Upgrade NATS Client to 2.11.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ micronautTestVersion=2.3.2
 groovyVersion=3.0.5
 spockVersion=2.0-M3-groovy-3.0
 
-natsVersion=2.8.0
+natsVersion=2.11.0
 
 title=Micronaut Nats
 projectDesc=Integration between Micronaut and nats.io


### PR DESCRIPTION
NATS client (jnats) is released some days ago, and both 2.10.0 and 2.11.0 come with interesting features
- https://github.com/nats-io/nats.java/releases/tag/2.11.0