### PR TITLE
Migrate to build 6.1.1 and cleanup

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Publish to Sonatype OSSRH
         env:

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -58,7 +58,7 @@ jobs:
            PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.6.2
         with:
           check_name: GraalVM CE CI / Test Report (Java ${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,7 +60,7 @@ jobs:
            PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.6.2
         with:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Publish to Sonatype Snapshots
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '17'
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:17}
+        run: echo ::set-output name=release_version::${GITHUB_REF:11}
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Set the current release version
         id: release_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '17'
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:11}
+        run: echo ::set-output name=release_version::${GITHUB_REF:17}
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
       - name: Optional setup step
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,8 @@ plugins {
     id 'io.micronaut.build.internal.quality-reporting'
 }
 
-allprojects {
-    repositories {
-        mavenCentral()
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
-    }
+repositories {
+    mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
+

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-base.gradle
@@ -1,0 +1,4 @@
+repositories {
+    mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-base.gradle
@@ -2,3 +2,14 @@ repositories {
     mavenCentral()
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
+
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute(module("org.codehaus.groovy:groovy"))
+                .using(module("org.apache.groovy:groovy:${libs.versions.groovy.get()}"))
+    }
+}
+
+tasks.withType(GroovyCompile).configureEach {
+    options.forkOptions.jvmArgs << '-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true'
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-module.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id "io.micronaut.build.internal.nats-base"
+    id "io.micronaut.build.internal.module"
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-tests.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.nats-tests.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "io.micronaut.build.internal.nats-base"
+}

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,11 +96,13 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="excludeScope" value="private"/>
+            <property name="accessModifiers" value="public, protected"/>
         </module>
         <module name="JavadocType"/>
         <module name="JavadocStyle"/>
-        <module name="MissingJavadocType"/>
+        <module name="MissingJavadocType">
+            <property name="severity" value="warning"/>
+        </module>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->

--- a/docs-examples/example-groovy/build.gradle
+++ b/docs-examples/example-groovy/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "groovy"
+    id 'io.micronaut.build.internal.nats-tests'
 }
 
 repositories {

--- a/docs-examples/example-groovy/build.gradle
+++ b/docs-examples/example-groovy/build.gradle
@@ -14,9 +14,9 @@ dependencies {
     testImplementation libs.testcontainers.spock
     testImplementation mn.micronaut.inject
     testImplementation mn.reactor
-    testImplementation mn.micronaut.test.spock
-    testImplementation mn.spock
+    testImplementation mnTest.micronaut.test.spock
     testRuntimeOnly libs.junit.jupiter.engine
+    testRuntimeOnly mn.snakeyaml
 }
 
 test {

--- a/docs-examples/example-java/build.gradle
+++ b/docs-examples/example-java/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java-library"
+    id 'io.micronaut.build.internal.nats-tests'
 }
 
 dependencies {

--- a/docs-examples/example-java/build.gradle
+++ b/docs-examples/example-java/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testImplementation libs.testcontainers
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
+    testRuntimeOnly mn.snakeyaml
 }
 
 compileJava.options.compilerArgs += '-parameters'

--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias libs.plugins.kotlin.jvm
     alias libs.plugins.kotlin.kapt
+    id 'io.micronaut.build.internal.nats-tests'
 }
 
 dependencies {
@@ -27,18 +28,5 @@ compileTestKotlin {
     kotlinOptions {
         jvmTarget = '17'
         javaParameters = true
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
-}
-
-test {
-    useJUnitPlatform()
-    testLogging {
-        showStandardStreams = true
-        exceptionFormat = 'full'
     }
 }

--- a/docs-examples/example-kotlin/build.gradle
+++ b/docs-examples/example-kotlin/build.gradle
@@ -8,12 +8,11 @@ dependencies {
     kaptTest(mn.micronaut.inject.java)
 
     testImplementation projects.nats
-    testImplementation libs.kotest
-    testImplementation libs.kotlin.reflect
-    testImplementation libs.kotlin.stdlib
+    testImplementation mnTest.micronaut.test.kotest5
     testImplementation libs.testcontainers
     testImplementation mn.reactor
     testRuntimeOnly libs.junit.jupiter.engine
+    testRuntimeOnly mn.snakeyaml
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ nats = '2.16.5'
 [libraries]
 jnats = { module = 'io.nats:jnats', version.ref = 'nats'}
 awaitility = { module = 'org.awaitility:awaitility', version.ref = 'awaitility' }
+caffeine = { module = 'com.github.ben-manes.caffeine:caffeine', version.ref = 'caffeine' }
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }
 kotest = { module = 'io.kotest:kotest-runner-junit5', version.ref = 'kotest' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ awaitility = '4.2.0'
 junit = '5.9.1'
 kotest = '5.5.4'
 kotlin = '1.7.22'
-testcontainers = '1.17.5'
+testcontainers = '1.17.6'
 nats = '2.16.5'
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,30 +1,32 @@
 [versions]
 micronaut = '4.0.0-SNAPSHOT'
 micronaut-docs = '2.0.0'
-micronaut-test = '3.7.0'
+micronaut-test = '4.0.0-SNAPSHOT'
 groovy = "4.0.6"
 spock = "2.3-groovy-4.0"
 
-
 awaitility = '4.2.0'
 junit = '5.9.1'
-kotest = '5.5.4'
 kotlin = '1.7.22'
 testcontainers = '1.17.6'
 nats = '2.16.5'
 
+micronaut-micrometer = "4.6.1" # TODO update once 5.0.0-SNAPSHOT is out
+micronaut-reactor = "3.0.0-SNAPSHOT"
+micronaut-serde = "2.0.0-SNAPSHOT"
 
 [libraries]
 jnats = { module = 'io.nats:jnats', version.ref = 'nats'}
 awaitility = { module = 'org.awaitility:awaitility', version.ref = 'awaitility' }
-caffeine = { module = 'com.github.ben-manes.caffeine:caffeine', version.ref = 'caffeine' }
+
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }
-kotest = { module = 'io.kotest:kotest-runner-junit5', version.ref = 'kotest' }
-kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' }
-kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib-jdk8', version.ref = 'kotlin' }
 testcontainers = { module = 'org.testcontainers:testcontainers', version.ref = 'testcontainers' }
 testcontainers-spock = { module = 'org.testcontainers:spock', version.ref = 'testcontainers' }
+
+micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
+micronaut-reactor = { module = 'io.micronaut.reactor:micronaut-reactor-bom', version.ref = "micronaut-reactor" }
+micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 
 [plugins]
 kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }

--- a/nats/build.gradle
+++ b/nats/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.module'
+    id 'io.micronaut.build.internal.nats-module'
 }
 
 dependencies {

--- a/nats/build.gradle
+++ b/nats/build.gradle
@@ -3,23 +3,18 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
-
     api mn.micronaut.messaging
     api libs.jnats
 
-    implementation mn.micronaut.serde.jackson
-    implementation mn.micronaut.reactor
+    implementation mnSerde.micronaut.serde.jackson
+    implementation mnReactor.micronaut.reactor
 
     compileOnly mn.micronaut.management
-    compileOnly mn.micronaut.micrometer.core
+    compileOnly mnMicrometer.micronaut.micrometer.core
 
     testImplementation libs.testcontainers.spock
-    testImplementation mn.micronaut.inject.groovy
-    testImplementation mn.micronaut.inject.java
     testImplementation mn.micronaut.management
-    testImplementation mn.micronaut.test.spock
-    testImplementation mn.spock
+    testImplementation mnTest.micronaut.test.spock
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,13 +19,10 @@ include 'docs-examples:example-kotlin'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
-    }
-}
-
 micronautBuild {
+    addSnapshotRepository()
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-micrometer")
+    importMicronautCatalog("micronaut-reactor")
+    importMicronautCatalog("micronaut-serde")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.0.2"
+    id("io.micronaut.build.shared.settings") version "6.1.1"
 }
 
 rootProject.name = 'nats-parent'


### PR DESCRIPTION
The state of the nats module for Micronaut 4 was a bit out of sync, with some duplication of effort for the migration to Micronaut 4 merged to both master and the 4.0.x branch. Since master is now the branch for Micronaut 4.0.0 development, I created this branch from master, merged and resolved prior Micronaut 4 changes from the 4.0.x branch, and  deleted the 4.0.x branch. I also merged all the relevant build and renovate PRs, migrated everything to work with build plugins 6.1.1. and cleaned up everything related to build. Merging this PR to master should result with everything in the state it should be.