### PR TITLE
Fix dynamic headers isolation

### DIFF
--- a/docs-examples/example-groovy/src/test/groovy/io/micronaut/nats/docs/headers/HeadersSpec.groovy
+++ b/docs-examples/example-groovy/src/test/groovy/io/micronaut/nats/docs/headers/HeadersSpec.groovy
@@ -28,7 +28,7 @@ class HeadersSpec extends AbstractNatsTest {
             productListener.messageProperties.size() == 6
             productListener.messageProperties.contains("true|10|small")
             productListener.messageProperties.contains("true|20|medium")
-            productListener.messageProperties.contains("true|30|medium")
+            productListener.messageProperties.contains("true|30|null")
             productListener.messageProperties.contains("true|40|large")
             productListener.messageProperties.contains("true|20|xtra-small")
             productListener.messageProperties.contains("true|20|xtra-large")

--- a/docs-examples/example-java/src/test/java/io/micronaut/nats/docs/headers/HeadersSpec.java
+++ b/docs-examples/example-java/src/test/java/io/micronaut/nats/docs/headers/HeadersSpec.java
@@ -31,7 +31,7 @@ class HeadersSpec extends AbstractNatsTest {
                 productListener.messageProperties.size() == 6 &&
                 productListener.messageProperties.contains("true|10|small") &&
                 productListener.messageProperties.contains("true|20|medium") &&
-                productListener.messageProperties.contains("true|30|medium") &&
+                productListener.messageProperties.contains("true|30|null") &&
                 productListener.messageProperties.contains("true|40|large") &&
                 productListener.messageProperties.contains("true|20|xtra-small") &&
                 productListener.messageProperties.contains("true|20|xtra-large")

--- a/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/nats/docs/headers/HeadersSpec.kt
+++ b/docs-examples/example-kotlin/src/test/kotlin/io/micronaut/nats/docs/headers/HeadersSpec.kt
@@ -38,7 +38,7 @@ class HeadersSpec : AbstractNatsTest({
                     productListener.messageProperties.size shouldBe 6
                     productListener.messageProperties shouldContain "true|10|small"
                     productListener.messageProperties shouldContain "true|20|medium"
-                    productListener.messageProperties shouldContain "true|30|medium"
+                    productListener.messageProperties shouldContain "true|30|null"
                     productListener.messageProperties shouldContain "true|40|large"
                     productListener.messageProperties shouldContain "true|20|xtra-small"
                     productListener.messageProperties shouldContain "true|20|xtra-large"

--- a/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
+++ b/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
@@ -149,7 +149,11 @@ public abstract class AbstractIntroductionAdvice {
                     getNameAndValue(argument, headerAnn, parameterValues);
                 String name = entry.getKey();
                 List<String> value = entry.getValue();
-                headers.put(name, value);
+                if (value.isEmpty() && headers.containsKey(name)) {
+                    headers.remove(name);
+                } else {
+                    headers.put(name, value);
+                }
             } else if (headersObject) {
                 Headers dynamicHeaders = (Headers) parameterValues.get(argument.getName());
                 dynamicHeaders.forEach(headers::put);

--- a/nats/src/main/java/io/micronaut/nats/intercept/StaticPublisherState.java
+++ b/nats/src/main/java/io/micronaut/nats/intercept/StaticPublisherState.java
@@ -107,7 +107,7 @@ public class StaticPublisherState {
      * @return the method headers
      */
     public Headers getHeaders() {
-        return headers;
+        return new Headers(headers);
     }
 
     /**

--- a/nats/src/test/groovy/io/micronaut/nats/annotation/HeaderSpec.groovy
+++ b/nats/src/test/groovy/io/micronaut/nats/annotation/HeaderSpec.groovy
@@ -37,10 +37,14 @@ class HeaderSpec extends AbstractNatsTest {
         producer.go(true, "myHeader1")
         producer.go(true, "myHeader2")
 
-        Headers headers = new Headers();
-        headers.put("test", "1","2","3","4")
-        headers.put("test1", "5");
-        producer.testHeaders(false, headers)
+        Headers headersFirst = new Headers()
+        headersFirst.put("test", "1","2","3","4")
+        headersFirst.put("test1", "5")
+        producer.testHeaders(false, headersFirst)
+
+        Headers headersSecond = new Headers()
+        headersSecond.put("test1", "6")
+        producer.testHeaders(false, headersSecond)
 
         producer.testHeadersList(false, ["test1", "test2"])
 
@@ -50,8 +54,8 @@ class HeaderSpec extends AbstractNatsTest {
             singleTokenConsumer.simpleHeaders[0] == 'myHeader1'
             singleTokenConsumer.simpleHeaders[1] == 'myHeader2'
 
-            singleTokenConsumer.natsHeaders.size() == 5
-            singleTokenConsumer.natsHeaders == ["1", "2", "3", "4", "5"]
+            singleTokenConsumer.natsHeaders.size() == 6
+            singleTokenConsumer.natsHeaders == ["1", "2", "3", "4", "5", "6"]
 
             singleTokenConsumer.headerList.size() == 2
             singleTokenConsumer.headerList == ["test1", "test2"]

--- a/src/main/docs/guide/producer/producerMethods/producerParameters/producerHeaders.adoc
+++ b/src/main/docs/guide/producer/producerMethods/producerParameters/producerHeaders.adoc
@@ -4,6 +4,6 @@ snippet::io.micronaut.nats.docs.headers.ProductClient[tags="imports,clazz", proj
 
 <1> Headers can be defined at the class level and will apply to all methods. If a header is defined on the method with the same name as one on the class, the value on the method will be used.
 <2> Multiple annotations can be used to set multiple headers on the method or class level.
-<3> Headers can be set per execution. The name is inferred from the argument if the annotation value is not set. Null values will be ignored.
-<4> You can also use a List as header.
-<5> A `Headers` argument can be used to pass custom headers.
+<3> Headers can be set per execution. The name is inferred from the argument if the annotation value is not set. A null value results in the header not being set.
+<4> You can also use a List as header. An empty list or a null value do not set the header.
+<5> A `Headers` argument can be used to pass custom headers. Note: if the `@MessageHeader` is used on a method argument, the `Headers` argument will be ignored.


### PR DESCRIPTION
When using dynamic headers and calling the same producer method multiple times with different header keys, the headers from previous calls "leak" into subsequent ones due to the shared `StaticPublisherState` and `getHeaders()` implementation. This is illustrated inside `nats/src/test/groovy/io/micronaut/nats/annotation/HeaderSpec.groovy` where without this fix the second call to `producer.testHeaders()` would also send the `test` header with the values from the previous call.

This was also reflected in the documentation example. The value `true|30|medium` was a result of the `productClient.send(null, 30L, "body3".getBytes())` although the `productSize` was `null` and the default is set to `large`. This was because the previous method invocation had `medium` for `productSize`.

The solution is to return a copy of headers on `StaticPublisherState.getHeaders()`.

For a scenario such as one in the example where a header annotation is defined on the class level and on the method level, when on the method invocation a `null` value is provided for the header value, the header should not be sent. This is the reason for the change in `AbstractIntroductionAdvice` and removing the header if set by a class-level annotation (nats.io client ignores null/empty array values).