### PR TITLE
correctly resolve header name from argument name

### DIFF
--- a/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
+++ b/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
@@ -250,8 +250,7 @@ public abstract class AbstractIntroductionAdvice {
                                                             AnnotationValue<?> annotationValue,
                                                             Map<String, Object> parameterValues) {
         String argumentName = argument.getName();
-        String name = annotationValue.get("name", String.class)
-            .filter(StringUtils::isNotEmpty)
+        String name = annotationValue.stringValue("name")
             .orElse(annotationValue.stringValue().orElse(argumentName));
         Optional<List> value =
             conversionService.convert(parameterValues.get(argumentName),

--- a/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
+++ b/nats/src/main/java/io/micronaut/nats/intercept/AbstractIntroductionAdvice.java
@@ -251,6 +251,7 @@ public abstract class AbstractIntroductionAdvice {
                                                             Map<String, Object> parameterValues) {
         String argumentName = argument.getName();
         String name = annotationValue.get("name", String.class)
+            .filter(StringUtils::isNotEmpty)
             .orElse(annotationValue.stringValue().orElse(argumentName));
         Optional<List> value =
             conversionService.convert(parameterValues.get(argumentName),


### PR DESCRIPTION
if the name in the annotation is empty, use the argument name as header key