### PR TITLE
Correct bean type for factory methods

### DIFF
--- a/nats/src/main/java/io/micronaut/nats/jetstream/KeyValueFactory.java
+++ b/nats/src/main/java/io/micronaut/nats/jetstream/KeyValueFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.nats.jetstream;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.InjectionPoint;
@@ -32,7 +33,6 @@ import io.nats.client.KeyValueManagement;
 import io.nats.client.KeyValueOptions;
 import io.nats.client.api.KeyValueConfiguration;
 import io.nats.client.api.KeyValueStatus;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 
@@ -104,7 +104,7 @@ public class KeyValueFactory {
      * @return The key value bucket
      * @throws IOException in case of communication issue
      */
-    @Singleton
+    @Prototype
     KeyValue keyvalue(@Nullable InjectionPoint<?> injectionPoint) throws IOException {
         if (injectionPoint == null) {
             return null;

--- a/nats/src/main/java/io/micronaut/nats/jetstream/ObjectStoreFactory.java
+++ b/nats/src/main/java/io/micronaut/nats/jetstream/ObjectStoreFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.nats.jetstream;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Nullable;
@@ -31,7 +32,6 @@ import io.nats.client.ObjectStore;
 import io.nats.client.ObjectStoreManagement;
 import io.nats.client.ObjectStoreOptions;
 import io.nats.client.api.ObjectStoreConfiguration;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 
@@ -88,7 +88,7 @@ public class ObjectStoreFactory {
      * @return The object store
      * @throws IOException in case of communication issue
      */
-    @Singleton
+    @Prototype
     ObjectStore objectStore(@Nullable InjectionPoint<?> injectionPoint) throws IOException {
         if (injectionPoint == null) {
             return null;

--- a/nats/src/main/java/io/micronaut/nats/jetstream/annotation/KeyValueStore.java
+++ b/nats/src/main/java/io/micronaut/nats/jetstream/annotation/KeyValueStore.java
@@ -17,7 +17,6 @@ package io.micronaut.nats.jetstream.annotation;
 
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.nats.annotation.NatsConnection;
-import jakarta.inject.Singleton;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -33,7 +32,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Singleton
 public @interface KeyValueStore {
 
     /**

--- a/nats/src/test/groovy/io/micronaut/nats/jetstream/AbstractJetstreamTest.groovy
+++ b/nats/src/test/groovy/io/micronaut/nats/jetstream/AbstractJetstreamTest.groovy
@@ -38,13 +38,16 @@ abstract class AbstractJetstreamTest extends Specification {
 
     protected ApplicationContext startContext(Map additionalConfig = [:]) {
         ApplicationContext.run(
-                ["nats.default.addresses": ["nats://localhost:${natsContainer.getMappedPort(4222)}"],
-                 "spec.name"             : getClass().simpleName,
-                 "nats.default.jetstream.streams.widgets.storage-type": "Memory",
-                 "nats.default.jetstream.streams.widgets.subjects": ['subject.>'],
-                 "nats.default.jetstream.keyvalue.examplebucket.storage-type": "Memory",
-                 "nats.default.jetstream.keyvalue.examplebucket.max-history-per-key": 5,
-                 "nats.default.jetstream.objectstore.examplestore.storage-type": "Memory"
+                ["nats.default.addresses"                                            : ["nats://localhost:${natsContainer.getMappedPort(4222)}"],
+                 "spec.name"                                                         : getClass().simpleName,
+                 "nats.default.jetstream.streams.widgets.storage-type"               : "Memory",
+                 "nats.default.jetstream.streams.widgets.subjects"                   : ['subject.>'],
+                 "nats.default.jetstream.keyvalue.examplebucket.storage-type"        : "Memory",
+                 "nats.default.jetstream.keyvalue.examplebucket.max-history-per-key" : 5,
+                 "nats.default.jetstream.keyvalue.examplebucket2.storage-type"       : "Memory",
+                 "nats.default.jetstream.keyvalue.examplebucket2.max-history-per-key": 5,
+                 "nats.default.jetstream.objectstore.examplestore.storage-type"      : "Memory",
+                 "nats.default.jetstream.objectstore.examplestore2.storage-type"     : "Memory"
                 ] << additionalConfig, "test")
     }
 }

--- a/nats/src/test/groovy/io/micronaut/nats/jetstream/KeyValueSpec.groovy
+++ b/nats/src/test/groovy/io/micronaut/nats/jetstream/KeyValueSpec.groovy
@@ -111,12 +111,40 @@ class KeyValueSpec extends AbstractJetstreamTest {
         applicationContext.close()
     }
 
+    void "mutliple injects via injection point"() {
+        given:
+        ApplicationContext applicationContext = startContext()
+        KeyValueManagement kvm = applicationContext.getBean(KeyValueManagement, Qualifiers.byName(NatsConnection.DEFAULT_CONNECTION))
+
+        when:
+        def keyValueHolder = applicationContext.getBean(KeyValueHolder)
+
+        then:
+        keyValueHolder.keyValueBucket != null
+        keyValueHolder.exampleBucket2 != null
+
+        when:
+        keyValueHolder.keyValueBucket.put("testKey1", "testValue1")
+        keyValueHolder.exampleBucket2.put("testKey2", "testValue2")
+
+        then:
+        keyValueHolder.keyValueBucket.get("testKey1").getValueAsString() == "testValue1"
+        keyValueHolder.exampleBucket2.get("testKey2").getValueAsString() == "testValue2"
+
+        cleanup:
+        applicationContext.close()
+    }
+
 
     @Requires(property = 'spec.name', value = 'KeyValueSpec')
     @Singleton
     static class KeyValueHolder {
         @Inject
         @KeyValueStore('examplebucket')
-        KeyValue keyValueBucket;
+        KeyValue keyValueBucket
+
+        @Inject
+        @KeyValueStore('examplebucket2')
+        KeyValue exampleBucket2
     }
 }

--- a/nats/src/test/groovy/io/micronaut/nats/jetstream/ObjectStoreSpec.groovy
+++ b/nats/src/test/groovy/io/micronaut/nats/jetstream/ObjectStoreSpec.groovy
@@ -83,6 +83,38 @@ class ObjectStoreSpec extends AbstractJetstreamTest {
         applicationContext.close()
     }
 
+    void "mutliple injects via injection point"() {
+        given:
+        ApplicationContext applicationContext = startContext()
+        ObjectStoreManagement osm = applicationContext.getBean(ObjectStoreManagement, Qualifiers.byName(NatsConnection.DEFAULT_CONNECTION))
+        def testValue1 = "Test Value 1".getBytes()
+        def testValue2 = "Test Value 2".getBytes()
+
+
+        when:
+        def objectStoreHolder = applicationContext.getBean(ObjectStoreHolder)
+
+        then:
+        objectStoreHolder.objectStore != null
+        objectStoreHolder.exampleStore2 != null
+
+        when:
+        objectStoreHolder.objectStore.put("testKey", testValue1)
+        objectStoreHolder.exampleStore2.put("testKey", testValue2)
+
+        then:
+        def baos1 = new ByteArrayOutputStream()
+        objectStoreHolder.objectStore.get("testKey", baos1)
+        testValue1 == baos1.toByteArray()
+
+        def baos2 = new ByteArrayOutputStream()
+        objectStoreHolder.exampleStore2.get("testKey", baos2)
+        testValue2 == baos2.toByteArray()
+
+        cleanup:
+        applicationContext.close()
+    }
+
 
     @Requires(property = 'spec.name', value = 'ObjectStoreSpec')
     @Singleton
@@ -90,6 +122,10 @@ class ObjectStoreSpec extends AbstractJetstreamTest {
 
         @Inject
         @ObjectStore("examplestore")
-        io.nats.client.ObjectStore objectStore;
+        io.nats.client.ObjectStore objectStore
+
+        @Inject
+        @ObjectStore("examplestore2")
+        io.nats.client.ObjectStore exampleStore2;
     }
 }


### PR DESCRIPTION
The KeyValueFactory and ObjectStoreFactory produced singletons instead of prototypes. This caused an issue that not multiple key or object stores could be injected into the same class.