### PR TITLE
Docs fail with 4102

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ kotlin = '1.9.25'
 nats = '2.23.0'
 
 micronaut-logging = "1.7.1"
-micronaut-reactor = "3.8.0"
 micronaut-micrometer = "5.13.0"
+micronaut-reactor = "3.9.0"
 micronaut-rxjava3 = "3.8.0"
 micronaut-serde = "2.15.5"
 micronaut-test-resources="2.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.9.12"
+micronaut = "4.10.2"
 micronaut-platform = "4.9.4"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.7.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ kotlin = '1.9.25'
 nats = '2.23.0'
 
 micronaut-logging = "1.7.1"
-micronaut-micrometer = "5.12.0"
 micronaut-reactor = "3.8.0"
+micronaut-micrometer = "5.13.0"
 micronaut-rxjava3 = "3.8.0"
 micronaut-serde = "2.15.1"
 micronaut-test-resources="2.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ micronaut-logging = "1.7.1"
 micronaut-reactor = "3.8.0"
 micronaut-micrometer = "5.13.0"
 micronaut-rxjava3 = "3.8.0"
-micronaut-serde = "2.15.1"
+micronaut-serde = "2.15.5"
 micronaut-test-resources="2.10.1"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 micronaut = "4.10.4"
 micronaut-platform = "4.9.4"
 micronaut-docs = "3.0.0"
-micronaut-test = "4.7.0"
+micronaut-test = "4.9.0"
 micronaut-gradle-plugin = "4.5.5"
 groovy = "4.0.24"
 spock = "2.3-groovy-4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.10.2"
+micronaut = "4.10.4"
 micronaut-platform = "4.9.4"
 micronaut-docs = "3.0.0"
 micronaut-test = "4.7.0"

--- a/src/main/docs/guide/jetstream/keyvalue/kv_configuration.adoc
+++ b/src/main/docs/guide/jetstream/keyvalue/kv_configuration.adoc
@@ -2,7 +2,7 @@ All properties on the link:{apinats}/io/nats/client/JetStreamOptions.Builder.htm
 
 The following properties are available for a stream configuration:
 
-include::{includedir}configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$KeyValueConfiguration.adoc[]
+include::{includedir}configurationProperties/io.nats.client.api.KeyValueConfiguration$Builder.adoc[]
 
 A simple configuration for key value can look like:
 

--- a/src/main/docs/guide/jetstream/objectstore/os_configuration.adoc
+++ b/src/main/docs/guide/jetstream/objectstore/os_configuration.adoc
@@ -1,6 +1,6 @@
 All properties on the link:{apinats}/io/nats/client/JetStreamOptions.Builder.html[JetStreamOptions.Builder] and link:{apinats}/io/nats/client/api/ObjectStoreConfiguration.Builder.html[ObjectStoreConfiguration.Builder] are available to be modified, either through configuration or a link:{apimicronaut}context/event/BeanCreatedEventListener.html[BeanCreatedEventListener].
 
-include::{includedir}configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$ObjectStoreConfiguration.adoc[]
+include::{includedir}configurationProperties/io.nats.client.api.ObjectStoreConfiguration$Builder.adoc[]
 
 A simple configuration for key value can look like:
 

--- a/src/main/docs/guide/jetstream/streams/configuration.adoc
+++ b/src/main/docs/guide/jetstream/streams/configuration.adoc
@@ -2,7 +2,7 @@ All properties on the link:{apinats}/io/nats/client/JetStreamOptions.Builder.htm
 
 The following properties are available for a stream configuration:
 
-include::{includedir}configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$StreamConfiguration.adoc[]
+include::{includedir}configurationProperties/io.nats.client.api.StreamConfiguration$Builder.adoc[]
 
 A simple configuration for jetstream and a single stream can look like:
 


### PR DESCRIPTION
Steps to reproduce. Close this branch `./gradlew clean docs`

Updating to 4.10.2 fails docs generation. 

```
In file index.html
    <p>Unresolved directive in &lt;stdin&gt; - include::/Users/sdelamo/github/micronaut-projects/micronaut-nats/build/working/01-includes/configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$StreamConfiguration.adoc[]</p>
    <p>Unresolved directive in &lt;stdin&gt; - include::/Users/sdelamo/github/micronaut-projects/micronaut-nats/build/working/01-includes/configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$KeyValueConfiguration.adoc[]</p>
    <p>Unresolved directive in &lt;stdin&gt; - include::/Users/sdelamo/github/micronaut-projects/micronaut-nats/build/working/01-includes/configurationProperties/io.micronaut.nats.connect.NatsConnectionFactoryConfig$JetStreamConfiguration$ObjectStoreConfiguration.adoc[]</p>
```

Those configuration reference files are no longer generated: 
<img width="612" height="193" alt="Screenshot 2025-10-08 at 11 28 02" src="https://github.com/user-attachments/assets/6dd6f11a-d542-4d87-aa8f-eb6caaa7d15d" />

see: 
https://github.com/micronaut-projects/micronaut-nats/blob/5.0.x/nats/src/main/java/io/micronaut/nats/connect/NatsConnectionFactoryConfig.java#L473
